### PR TITLE
Enforce Node Version to v16.13.1

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Getting Started
+
+First ensure you're on node version **v16.13.1**. `.nvmrc` will enforce this version.  
+Recommended node version managers: **[n](https://github.com/tj/n)** or **[nvm](https://github.com/nvm-sh/nvm)**
+
+Install dependencies
+
+```bash
+ > npm install
+```
+
+Rollup
+
+```bash
+ > npm run rollup
+```
+
+Run Storybook
+```bash
+ > npm run storybook
+```

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@thistle-strum/react-component-library",
   "version": "0.1.2",
   "description": "A simple template for a custom React component library",
+  "engines": {
+    "node": "16.13.1"
+  },
   "scripts": {
     "rollup": "rollup -c",
     "test": "jest",


### PR DESCRIPTION
### 🔥 Summary
Enforce Node Version

### 😤 Problem / Goals
- One easy place to understand what node version to develop/build on

### 🤓 Solution
- Add an .nvmrc file making node version strict
- Add node engine version to package.json

### 🗒️ Additional Notes
- Also adds basic readme for setup guide