### PR TITLE
Improve component typings

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import "tailwindcss/tailwind.css";
 
-import Button from "./Button";
+import { Button } from "./Button";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,28 +1,23 @@
 import React, { MouseEventHandler } from "react";
 
 export interface ButtonProps {
-  label: string;
-  onClick: MouseEventHandler<HTMLButtonElement>;
+  readonly label: string;
+  readonly onClick: MouseEventHandler<HTMLButtonElement>;
 }
 
-function onClick() {
-  console.log("test");
-}
-
-const Button = (props: ButtonProps) => {
+export const Button: React.VFC<ButtonProps> = ({ label, onClick }) => {
   return (
     <div>
       <button
         onClick={onClick}
-        className="bg-[#FA001E] hover:bg-red-700 mb-3 sm:ml-0 inline-flex items-center px-8 pb-2 pt-2 border border-white text-base font-medium rounded-md shadow-sm text-white  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-${variant} border disabled:bg-gray-300 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
+        className="bg-[#FA001E] hover:bg-red-700 mb-3 sm:ml-0 inline-flex items-center px-8 pb-2 pt-2 border border-white text-base font-medium rounded-md shadow-sm text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-${variant} border disabled:bg-gray-300 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none"
       >
-        {props.label}
+        {label}
       </button>
       <button className="bg-[#0320A5] hover:bg-blue-700 mb-3 sm:ml-0 inline-flex items-center px-8 pb-2 pt-2 border border-white text-base font-medium rounded-md shadow-sm text-white  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-${variant} border disabled:bg-gray-300 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none">
-        {props.label}
+        {label}
       </button>
     </div>
   );
 };
 
-export default Button;

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Button";
+export { Button, ButtonProps } from "./Button";

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import "tailwindcss/tailwind.css";
 
-import Checkbox from "./Checkbox";
+import { Checkbox } from "./Checkbox";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {
@@ -13,7 +13,9 @@ export default {
 } as ComponentMeta<typeof Checkbox>;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof Checkbox> = (...args) => <Checkbox />;
+const Template: ComponentStory<typeof Checkbox> = (...args) => (
+  <Checkbox label="test" />
+);
 
 export const SelfieCheckbox = Template.bind({});
 // More on args: https://storybook.js.org/docs/react/writing-stories/args

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 
 export interface CheckboxProps {
-  label: string;
+  readonly label: string;
 }
 
-const Checkbox = () => {
-  return <div></div>;
+export const Checkbox: React.VFC<CheckboxProps> = ({ label }) => {
+  return <div>{label}</div>;
 };
-
-export default Checkbox;

--- a/src/components/Checkbox/index.ts
+++ b/src/components/Checkbox/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Checkbox";
+export { Checkbox, CheckboxProps } from "./Checkbox";

--- a/src/components/DeployStatusCard/DeployStatusCard.stories.tsx
+++ b/src/components/DeployStatusCard/DeployStatusCard.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import "tailwindcss/tailwind.css";
+
+import { DeployStatusCard } from "./DeployStatusCard";
+
+const deployArray = [
+  { timestamp: "Aug 30, 2022 5:45:02 PM" },
+  {
+    deployHash:
+      "28b4fbf167b51213ff84663eea0b6075a447e85c22c63c36f9378c418f19a2b0",
+  },
+];
+
+export default {
+  title: "ReactComponentLibrary/DeployStatusCard",
+  component: DeployStatusCard,
+} as ComponentMeta<typeof DeployStatusCard>;
+
+const Template: ComponentStory<typeof DeployStatusCard> = (...args) => (
+  <DeployStatusCard deployInformation={deployArray as any} /> // we should see if we can't get this information as an object over an array
+);
+
+export const DeployStatusCardExample = Template.bind({});
+
+DeployStatusCardExample.args = {};

--- a/src/components/DeployStatusCard/DeployStatusCard.test.ts
+++ b/src/components/DeployStatusCard/DeployStatusCard.test.ts
@@ -1,0 +1,3 @@
+describe("DeployStatusCard", () => {
+  it("stub", () => {});
+});

--- a/src/components/DeployStatusCard/DeployStatusCard.tsx
+++ b/src/components/DeployStatusCard/DeployStatusCard.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from "react";
+
+export interface DeployStatusCardProps {
+  readonly deployInformation: { [key: string]: string }[];
+}
+
+export const DeployStatusCard: React.VFC<DeployStatusCardProps> = ({
+  deployInformation,
+}) => {
+  const deployHash = deployInformation[1].deployHash;
+
+  const truncatedDeployHash = useMemo(() => {
+    const startingSlice = deployHash.slice(0, 5);
+    const endingSlice = deployHash.slice(-6, -1);
+    return `${startingSlice}...${endingSlice}`;
+  }, [deployHash]);
+
+  return (
+    <section className="w-full max-w-3xl m-0 p-0">
+      <h2 className="text-3xl mb-4">
+        Deploy:{" "}
+        <span className="tracking-2 font-normal">{truncatedDeployHash}</span>
+      </h2>
+      <div className="max-w-3xl bg-[#FFF] shadow-card rounded px-4 pb-0 overflow-x-auto">
+        <table className="w-full">
+          <tbody>
+            <tr className="flex flex-row border-b border-[rgb(242, 243, 245)] border-solid py-2">
+              <td className="text-slate-500 whitespace-nowrap w-32">
+                Timestamp
+              </td>
+              <td>{deployInformation[0].timestamp}</td>
+            </tr>
+            <tr className="flex flex-row py-2">
+              <td className="text-slate-500 whitespace-nowrap w-32">
+                Deploy Hash
+              </td>
+              <td>
+                {deployHash}
+                &nbsp;
+                <button
+                  className="text-slate-500 hover:text-neutral-400 focus:text-green-400 transition-all"
+                  type="button"
+                  onClick={() => navigator.clipboard.writeText(deployHash)}
+                >
+                  Copy
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/src/components/DeployStatusCard/index.ts
+++ b/src/components/DeployStatusCard/index.ts
@@ -1,0 +1,1 @@
+export { DeployStatusCard } from "./DeployStatusCard";

--- a/src/components/Navbar/Navbar.stories.tsx
+++ b/src/components/Navbar/Navbar.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 import "tailwindcss/tailwind.css";
 
-import Navbar from "./Navbar";
+import { Navbar } from "./Navbar";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 export default {

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,7 +1,7 @@
-import React,{useState} from "react";
+import React, { useState } from "react";
 
 export interface NavProps {
-  label: string;
+  readonly label: string;
 }
 
 const navItems = [
@@ -22,37 +22,55 @@ const navItems = [
     path: "/test2",
   },
 ];
+
 //accepts arr of item objects
-export const Navbar = (props: NavProps) => {
+export const Navbar: React.VFC<NavProps> = ({ label }) => {
   const [isOpened, setIsOpened] = useState(false);
   return (
-    <nav className='py-10 px-10 bg-[#181B38]'>
-      <div className='flex flex-col lg:flex-row lg:justify-between'>
-        <div className='flex flex-row justify-between'>
-          <h1 className='m-0 text-green-500'>Logo</h1>
-          <div className= 'lg:hidden' onClick={()=> setIsOpened(!isOpened)} >
-            {isOpened?  
-              <svg fill='white' xmlns='http://www.w3.org/2000/svg' role='img' width='1.5em' height='1.5em' preserveAspectRatio='xMidYMid meet' viewBox='0 0 100 100'><path d='M84.707 68.752L65.951 49.998l18.75-18.752a1.989 1.989 0 0 0 0-2.813L71.566 15.295a1.99 1.99 0 0 0-2.814 0L49.999 34.047l-18.75-18.752c-.746-.747-2.067-.747-2.814 0L15.297 28.431a1.992 1.992 0 0 0 0 2.814L34.05 49.998L15.294 68.753a1.993 1.993 0 0 0 0 2.814L28.43 84.704a1.988 1.988 0 0 0 2.814 0l18.755-18.755l18.756 18.754c.389.388.896.583 1.407.583s1.019-.195 1.408-.583l13.138-13.137a1.99 1.99 0 0 0-.001-2.814z' fill='white'/></svg>
-              :<svg  fill='white' viewBox='0 0 100 80' width='20' height='20'><rect width='100' height='20'></rect><rect y='30' width='100' height='20'></rect><rect y='60' width='100' height='20'></rect>
+    <nav className="py-10 px-10 bg-[#181B38]">
+      <div className="flex flex-col lg:flex-row lg:justify-between">
+        <div className="flex flex-row justify-between">
+          <h1 className="m-0 text-green-500">Logo</h1>
+          <div className="lg:hidden" onClick={() => setIsOpened(!isOpened)}>
+            {isOpened ? (
+              <svg
+                fill="white"
+                xmlns="http://www.w3.org/2000/svg"
+                role="img"
+                width="1.5em"
+                height="1.5em"
+                preserveAspectRatio="xMidYMid meet"
+                viewBox="0 0 100 100"
+              >
+                <path
+                  d="M84.707 68.752L65.951 49.998l18.75-18.752a1.989 1.989 0 0 0 0-2.813L71.566 15.295a1.99 1.99 0 0 0-2.814 0L49.999 34.047l-18.75-18.752c-.746-.747-2.067-.747-2.814 0L15.297 28.431a1.992 1.992 0 0 0 0 2.814L34.05 49.998L15.294 68.753a1.993 1.993 0 0 0 0 2.814L28.43 84.704a1.988 1.988 0 0 0 2.814 0l18.755-18.755l18.756 18.754c.389.388.896.583 1.407.583s1.019-.195 1.408-.583l13.138-13.137a1.99 1.99 0 0 0-.001-2.814z"
+                  fill="white"
+                />
               </svg>
-            }
+            ) : (
+              <svg fill="white" viewBox="0 0 100 80" width="20" height="20">
+                <rect width="100" height="20"></rect>
+                <rect y="30" width="100" height="20"></rect>
+                <rect y="60" width="100" height="20"></rect>
+              </svg>
+            )}
           </div>
         </div>
-        <div onClick={()=> setIsOpened(!isOpened)}  className={`lg:flex lg:space-x-12 lg:flex-row lg:text-end lg:w-auto lg:p-0 ${isOpened? 'flex flex-col mt-10 lg:mt-0' : 'hidden' }`}>
+        <div
+          onClick={() => setIsOpened(!isOpened)}
+          className={`lg:flex lg:space-x-12 lg:flex-row lg:text-end lg:w-auto lg:p-0 ${
+            isOpened ? "flex flex-col mt-10 lg:mt-0" : "hidden"
+          }`}
+        >
           {navItems.map((item, index) => {
             return (
-              <a href={item.path} className='text-red-500 py-3 lg:py-0'>
+              <a href={item.path} className="text-red-500 py-3 lg:py-0">
                 {item.title}
               </a>
             );
           })}
-          </div>
+        </div>
       </div>
     </nav>
   );
-}
-
-export default Navbar;
-
-
-
+};

--- a/src/components/Navbar/index.ts
+++ b/src/components/Navbar/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Navbar";
+export { Navbar, NavProps } from "./Navbar";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 import "../index.css";
 
-export { default as Navbar } from "./Navbar";
-export { default as Button } from "./Button";
+export { Navbar } from "./Navbar";
+export { Button } from "./Button";
+export { Checkbox } from './Checkbox';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,5 @@ import "../index.css";
 
 export { Navbar } from "./Navbar";
 export { Button } from "./Button";
-export { Checkbox } from './Checkbox';
+export { Checkbox } from "./Checkbox";
+export { DeployStatusCard } from "./DeployStatusCard";

--- a/src/stories/Button.tsx
+++ b/src/stories/Button.tsx
@@ -5,35 +5,35 @@ interface ButtonProps {
   /**
    * Is this the principal call to action on the page?
    */
-  primary?: boolean;
+  readonly primary?: boolean;
   /**
    * What background color to use
    */
-  backgroundColor?: string;
+  readonly backgroundColor?: string;
   /**
    * How large should the button be?
    */
-  size?: 'small' | 'medium' | 'large';
+  readonly size?: 'small' | 'medium' | 'large';
   /**
    * Button contents
    */
-  label: string;
+  readonly label: string;
   /**
    * Optional click handler
    */
-  onClick?: () => void;
+  readonly onClick?: () => void;
 }
 
 /**
  * Primary UI component for user interaction
  */
-export const Button = ({
+export const Button: React.VFC<ButtonProps> = ({
   primary = false,
   size = 'medium',
   backgroundColor,
   label,
   ...props
-}: ButtonProps) => {
+}) => {
   const mode = primary ? 'storybook-button--primary' : 'storybook-button--secondary';
   return (
     <button

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,27 @@
 /** @type {import('tailwindcss').Config} */
+
+/* Helper Functions */
+// IMPORTANT: if we set the html font-size to a different value update the `base` here
+const pxToRem = (px, base = 16) => {
+  return `${px / base}rem`;
+};
+
+const letterSpacing = {
+  1: pxToRem(1),
+  2: pxToRem(2),
+  3: pxToRem(3),
+  4: pxToRem(4),
+};
+
+const boxShadow = {
+  card: 'rgb(143 144 152 / 15%) 0px 2px 4px',
+}
+
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
+    letterSpacing,
+    boxShadow,
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
### 🔥 Summary
Improve Casper component typings

### 😤 Problem / Goals
- Improve Casper components to have a more accurate type

### 🤓 Solution
- Convert component typings to `React.VFC` (Void Function Component; a.k.a. no children by default)
- Make all props  `readonly` since they should be treated as immutable

### 🗒️ Additional Notes
- A few export changes exist within this PR
- Default prettier rules have also made changes (will be updated once we have a prettierrc file in place)