### PR TITLE
Add deploy card

### DIFF
--- a/src/components/DeployStatusCard/DeployStatusCard.stories.tsx
+++ b/src/components/DeployStatusCard/DeployStatusCard.stories.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import "tailwindcss/tailwind.css";
+
+import { DeployStatusCard } from "./DeployStatusCard";
+
+const deployArray = [
+  { timestamp: "Aug 30, 2022 5:45:02 PM" },
+  {
+    deployHash:
+      "28b4fbf167b51213ff84663eea0b6075a447e85c22c63c36f9378c418f19a2b0",
+  },
+];
+
+export default {
+  title: "ReactComponentLibrary/DeployStatusCard",
+  component: DeployStatusCard,
+} as ComponentMeta<typeof DeployStatusCard>;
+
+const Template: ComponentStory<typeof DeployStatusCard> = (...args) => (
+  <DeployStatusCard deployInformation={deployArray as any} /> // we should see if we can't get this information as an object over an array
+);
+
+export const DeployStatusCardExample = Template.bind({});
+
+DeployStatusCardExample.args = {};

--- a/src/components/DeployStatusCard/DeployStatusCard.test.ts
+++ b/src/components/DeployStatusCard/DeployStatusCard.test.ts
@@ -1,0 +1,3 @@
+describe("DeployStatusCard", () => {
+  it("stub", () => {});
+});

--- a/src/components/DeployStatusCard/DeployStatusCard.tsx
+++ b/src/components/DeployStatusCard/DeployStatusCard.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from "react";
+
+export interface DeployStatusCardProps {
+  readonly deployInformation: { [key: string]: string }[];
+}
+
+export const DeployStatusCard: React.VFC<DeployStatusCardProps> = ({
+  deployInformation,
+}) => {
+  const deployHash = deployInformation[1].deployHash;
+
+  const truncatedDeployHash = useMemo(() => {
+    const startingSlice = deployHash.slice(0, 5);
+    const endingSlice = deployHash.slice(-6, -1);
+    return `${startingSlice}...${endingSlice}`;
+  }, [deployHash]);
+
+  return (
+    <section className="w-full max-w-3xl m-0 p-0">
+      <h2 className="text-3xl mb-4">
+        Deploy:{" "}
+        <span className="tracking-2 font-normal">{truncatedDeployHash}</span>
+      </h2>
+      <div className="max-w-3xl bg-[#FFF] shadow-card rounded px-4 pb-0 overflow-x-auto">
+        <table className="w-full">
+          <tbody>
+            <tr className="flex flex-row border-b border-[rgb(242, 243, 245)] border-solid py-2">
+              <td className="text-slate-500 whitespace-nowrap w-32">
+                Timestamp
+              </td>
+              <td>{deployInformation[0].timestamp}</td>
+            </tr>
+            <tr className="flex flex-row py-2">
+              <td className="text-slate-500 whitespace-nowrap w-32">
+                Deploy Hash
+              </td>
+              <td>
+                {deployHash}
+                &nbsp;
+                <button
+                  className="text-slate-500 hover:text-neutral-400 focus:text-green-400 transition-all"
+                  type="button"
+                  onClick={() => navigator.clipboard.writeText(deployHash)}
+                >
+                  Copy
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/src/components/DeployStatusCard/index.ts
+++ b/src/components/DeployStatusCard/index.ts
@@ -1,0 +1,1 @@
+export { DeployStatusCard } from "./DeployStatusCard";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,4 +2,5 @@ import "../index.css";
 
 export { Navbar } from "./Navbar";
 export { Button } from "./Button";
-export { Checkbox } from './Checkbox';
+export { Checkbox } from "./Checkbox";
+export { DeployStatusCard } from "./DeployStatusCard";

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,27 @@
 /** @type {import('tailwindcss').Config} */
+
+/* Helper Functions */
+// IMPORTANT: if we set the html font-size to a different value update the `base` here
+const pxToRem = (px, base = 16) => {
+  return `${px / base}rem`;
+};
+
+const letterSpacing = {
+  1: pxToRem(1),
+  2: pxToRem(2),
+  3: pxToRem(3),
+  4: pxToRem(4),
+};
+
+const boxShadow = {
+  card: 'rgb(143 144 152 / 15%) 0px 2px 4px',
+}
+
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
+    letterSpacing,
+    boxShadow,
     extend: {},
   },
   plugins: [],


### PR DESCRIPTION
### 🔥 Summary
Add deploy card similar to cspr.live deploy info card
<img width="1225" alt="Screen Shot 2022-08-30 at 5 02 45 PM" src="https://user-images.githubusercontent.com/26664788/187558426-ed87659f-b81e-481b-b469-64910c8d7c47.png">

### 😤 Problem / Goals
- Add new component for deploy information; very basic at this point in time
- We only have a subset of the full data to be displayed

### 🤓 Solution
- Uses table html elements
- Very basic click to copy added

### 🗒️ Additional Notes
- Make sure to set storybooks background to `light` to see card shadow properly

https://user-images.githubusercontent.com/26664788/187558614-0dd6c345-32f8-4b95-b442-4ca1a7982943.mov
